### PR TITLE
fixup issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/gobuildcache
+/gbc
+*.exe

--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 `gobuildcache` is a [`GOCACHEPROG`](https://github.com/golang/go/issues/59719) process using the [The Go Cloud Development Kit](https://gocloud.dev/) to support Azure, GCS and S3 storage providers.
 
+## install
+
+```shell
+go install github.com/saracen/gobuildcache@latest
+```
+
 ## usage
 
 ```shell
-export GOCACHEPROG="./gobuildcache <bucket url>"
+export GOCACHEPROG="gobuildcache <bucket url>"
 ```
 
 A readonly mode is supported, which works well if `?anonymous=true` is also passed as a bucket parameter to the bucket URL if the bucket is publically accessible. This parameter seems to only be supported by GCS and S3 though.

--- a/main.go
+++ b/main.go
@@ -137,8 +137,13 @@ func run(ctx context.Context, prefix, bucketURL string, readonly bool) error {
 	defer bucket.Close()
 	bucket = blob.PrefixedBucket(bucket, prefix)
 
-	cacher := &Cacher{}
-	cacher.disk = &Disk{cacheDir: filepath.Join(cacheDir, ".gocachebucket")}
+	return serve(ctx, bucket, filepath.Join(cacheDir, ".gocachebucket"), readonly, os.Stdin, originalStdout)
+}
+
+func serve(ctx context.Context, bucket *blob.Bucket, cacheDir string, readonly bool, in io.Reader, out io.Writer) error {
+	cacher := &Cacher{
+		disk: &Disk{cacheDir: cacheDir},
+	}
 	cacher.bucket = &Bucket{disk: cacher.disk, bucket: bucket}
 	cacher.bucket.Start(ctx)
 
@@ -154,10 +159,12 @@ func run(ctx context.Context, prefix, bucketURL string, readonly bool) error {
 		caps = append(caps, cmdPut)
 	}
 
-	r, w := bufio.NewReader(os.Stdin), bufio.NewWriter(originalStdout)
+	r, w := bufio.NewReader(in), bufio.NewWriter(out)
 	dec, enc := json.NewDecoder(r), json.NewEncoder(w)
 
-	enc.Encode(response{KnownCommands: caps})
+	if err := enc.Encode(response{KnownCommands: caps}); err != nil {
+		return err
+	}
 	if err := w.Flush(); err != nil {
 		return err
 	}
@@ -193,69 +200,70 @@ func run(ctx context.Context, prefix, bucketURL string, readonly bool) error {
 		}
 
 		go func() {
-			resp := &response{ID: req.ID}
-
-			defer func() {
-				// Only stat and populate response fields if we have a valid
-				// DiskPath. On cache miss, DiskPath is empty and we should not
-				// attempt to stat it (which would fail and incorrectly set Err).
-				if req.Command != cmdClose && resp.DiskPath != "" {
-					fi, err := os.Stat(resp.DiskPath)
-					if err != nil {
-						resp.Err = err.Error()
-					} else {
-						resp.OutputID, err = hex.DecodeString(filepath.Base(resp.DiskPath))
-						if err != nil {
-							resp.Err = "invalid output id"
-						}
-						resp.Size = fi.Size()
-						modTime := fi.ModTime()
-						resp.Time = &modTime
-					}
-				}
-
-				mu.Lock()
-				enc.Encode(resp)
-				w.Flush()
-				mu.Unlock()
-			}()
-
-			var err error
-			switch req.Command {
-			case cmdClose:
-				cacher.bucket.Close()
-
-			case cmdGet:
-				now := time.Now()
-				resp.DiskPath, err = cacher.Get(ctx, &req)
-				if err != nil {
-					slog.Error("get", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "err", err, "took", time.Since(now))
-				} else {
-					slog.Debug("get", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "took", time.Since(now))
-				}
-
-				if err != nil {
-					resp.Err = err.Error()
-				}
-				if resp.DiskPath == "" {
-					resp.Miss = true
-				}
-
-			case cmdPut:
-				now := time.Now()
-				resp.DiskPath, err = cacher.Put(ctx, &req)
-				if err != nil {
-					slog.Error("put", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "err", err, "took", time.Since(now))
-				} else {
-					slog.Debug("put", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "took", time.Since(now))
-				}
-
-				if err != nil {
-					resp.Err = err.Error()
-				}
-			}
+			resp := handleRequest(ctx, cacher, &req)
+			mu.Lock()
+			enc.Encode(resp)
+			w.Flush()
+			mu.Unlock()
 		}()
 	}
+}
+
+func handleRequest(ctx context.Context, c *Cacher, req *request) *response {
+	resp := &response{ID: req.ID}
+
+	var err error
+	switch req.Command {
+	case cmdClose:
+		c.bucket.Close()
+
+	case cmdGet:
+		now := time.Now()
+		resp.DiskPath, err = c.Get(ctx, req)
+		if err != nil {
+			slog.Error("get", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "err", err, "took", time.Since(now))
+			resp.Err = err.Error()
+		} else {
+			slog.Debug("get", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "took", time.Since(now))
+		}
+		if resp.DiskPath == "" {
+			resp.Miss = true
+		}
+
+	case cmdPut:
+		now := time.Now()
+		resp.DiskPath, err = c.Put(ctx, req)
+		if err != nil {
+			slog.Error("put", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "err", err, "took", time.Since(now))
+			resp.Err = err.Error()
+		} else {
+			slog.Debug("put", "action", hex.EncodeToString(req.ActionID), "output", resp.DiskPath, "took", time.Since(now))
+		}
+	}
+
+	populateFileInfo(req, resp)
+	return resp
+}
+
+// populateFileInfo fills Size/Time/OutputID from the on-disk artifact named by
+// resp.DiskPath. Skipped for cmdClose (no disk path) and on cache miss
+// (empty DiskPath would otherwise produce a spurious stat error).
+func populateFileInfo(req *request, resp *response) {
+	if req.Command == cmdClose || resp.DiskPath == "" {
+		return
+	}
+	fi, err := os.Stat(resp.DiskPath)
+	if err != nil {
+		resp.Err = err.Error()
+		return
+	}
+	resp.OutputID, err = hex.DecodeString(filepath.Base(resp.DiskPath))
+	if err != nil {
+		resp.Err = "invalid output id"
+	}
+	resp.Size = fi.Size()
+	modTime := fi.ModTime()
+	resp.Time = &modTime
 }
 
 var originalStdout = os.Stdout

--- a/main.go
+++ b/main.go
@@ -142,10 +142,10 @@ func run(ctx context.Context, prefix, bucketURL string, readonly bool) error {
 	cacher.bucket = &Bucket{disk: cacher.disk, bucket: bucket}
 	cacher.bucket.Start(ctx)
 
-	if err := os.MkdirAll(filepath.Join(cacher.disk.cacheDir, actionDir), 0o777); err != nil {
+	if err := os.MkdirAll(filepath.Join(cacher.disk.cacheDir, actionDir), 0o755); err != nil {
 		return fmt.Errorf("creating cache action dir: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Join(cacher.disk.cacheDir, outputDir), 0o777); err != nil {
+	if err := os.MkdirAll(filepath.Join(cacher.disk.cacheDir, outputDir), 0o755); err != nil {
 		return fmt.Errorf("creating cache output dir: %w", err)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"gocloud.dev/blob/memblob"
+)
+
+func TestFlagArray(t *testing.T) {
+	var fa flagArray
+	if err := fa.Set("a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fa.Set("b=c"); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"a", "b=c"}; !reflect.DeepEqual([]string(fa), want) {
+		t.Errorf("got %v, want %v", []string(fa), want)
+	}
+	if got, want := fa.String(), "[a b=c]"; got != want {
+		t.Errorf("String=%q, want %q", got, want)
+	}
+}
+
+func newCacher(t *testing.T) *Cacher {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{actionDir, outputDir} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	underlying := memblob.OpenBucket(nil)
+	t.Cleanup(func() { underlying.Close() })
+
+	c := &Cacher{disk: &Disk{cacheDir: dir}}
+	c.bucket = &Bucket{disk: c.disk, bucket: underlying}
+	c.bucket.Start(context.Background())
+	t.Cleanup(c.bucket.Close)
+	return c
+}
+
+func TestCacher_PutGetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+
+	content := []byte("payload")
+	outputID := sha256Bytes(content)
+	actionID := bytes.Repeat([]byte{0xab}, 32)
+
+	pathname, err := c.Put(ctx, &request{
+		ActionID: actionID,
+		OutputID: outputID,
+		Body:     bytes.NewReader(content),
+		BodySize: int64(len(content)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(pathname); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, content) {
+		t.Errorf("on-disk content mismatch")
+	}
+
+	got, err := c.Get(ctx, &request{ActionID: actionID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != pathname {
+		t.Errorf("Get=%q, want %q", got, pathname)
+	}
+}
+
+func TestCacher_GetMiss(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+
+	got, err := c.Get(ctx, &request{ActionID: bytes.Repeat([]byte{0xab}, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty on miss", got)
+	}
+}
+
+func TestPopulateFileInfo(t *testing.T) {
+	dir := t.TempDir()
+	outputID := strings.Repeat("a", 64)
+	pathname := filepath.Join(dir, outputID)
+	content := []byte("xyz")
+	if err := os.WriteFile(pathname, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("populates fields on hit", func(t *testing.T) {
+		req := &request{Command: cmdGet}
+		resp := &response{DiskPath: pathname}
+		populateFileInfo(req, resp)
+		if resp.Err != "" {
+			t.Errorf("unexpected Err=%q", resp.Err)
+		}
+		if resp.Size != int64(len(content)) {
+			t.Errorf("Size=%d, want %d", resp.Size, len(content))
+		}
+		if resp.Time == nil {
+			t.Error("Time was nil")
+		}
+		if len(resp.OutputID) != 32 {
+			t.Errorf("OutputID len=%d, want 32", len(resp.OutputID))
+		}
+	})
+
+	t.Run("missing file sets Err", func(t *testing.T) {
+		resp := &response{DiskPath: filepath.Join(dir, "nonexistent")}
+		populateFileInfo(&request{Command: cmdGet}, resp)
+		if resp.Err == "" {
+			t.Error("expected Err for missing file")
+		}
+	})
+
+	t.Run("close skips stat", func(t *testing.T) {
+		resp := &response{DiskPath: filepath.Join(dir, "nonexistent")}
+		populateFileInfo(&request{Command: cmdClose}, resp)
+		if resp.Err != "" {
+			t.Errorf("close should be skipped, got Err=%q", resp.Err)
+		}
+	})
+
+	t.Run("empty DiskPath skips stat", func(t *testing.T) {
+		resp := &response{}
+		populateFileInfo(&request{Command: cmdGet}, resp)
+		if resp.Err != "" {
+			t.Errorf("empty path should be skipped, got Err=%q", resp.Err)
+		}
+	})
+
+	t.Run("non-hex basename sets invalid output id", func(t *testing.T) {
+		bad := filepath.Join(dir, "not-hex")
+		if err := os.WriteFile(bad, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		resp := &response{DiskPath: bad}
+		populateFileInfo(&request{Command: cmdGet}, resp)
+		if resp.Err != "invalid output id" {
+			t.Errorf("Err=%q, want %q", resp.Err, "invalid output id")
+		}
+	})
+}
+
+func TestHandleRequest_Get(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+
+	content := []byte("hi")
+	outputID := sha256Bytes(content)
+	actionID := bytes.Repeat([]byte{0xab}, 32)
+
+	if _, err := c.Put(ctx, &request{
+		ActionID: actionID, OutputID: outputID,
+		Body: bytes.NewReader(content), BodySize: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := handleRequest(ctx, c, &request{ID: 7, Command: cmdGet, ActionID: actionID})
+	if resp.ID != 7 {
+		t.Errorf("ID=%d, want 7", resp.ID)
+	}
+	if resp.Err != "" {
+		t.Errorf("Err=%s", resp.Err)
+	}
+	if resp.Miss {
+		t.Error("Miss=true on hit")
+	}
+	if !bytes.Equal(resp.OutputID, outputID) {
+		t.Errorf("OutputID mismatch")
+	}
+	if resp.Size != int64(len(content)) {
+		t.Errorf("Size=%d, want %d", resp.Size, len(content))
+	}
+}
+
+func TestHandleRequest_GetMiss(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+
+	resp := handleRequest(ctx, c, &request{
+		ID: 5, Command: cmdGet,
+		ActionID: bytes.Repeat([]byte{0xab}, 32),
+	})
+	if !resp.Miss {
+		t.Error("expected Miss=true")
+	}
+	if resp.DiskPath != "" {
+		t.Errorf("DiskPath=%q, want empty", resp.DiskPath)
+	}
+}
+
+func TestHandleRequest_Put(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+
+	content := []byte("payload")
+	resp := handleRequest(ctx, c, &request{
+		ID: 9, Command: cmdPut,
+		ActionID: bytes.Repeat([]byte{0xab}, 32),
+		OutputID: sha256Bytes(content),
+		Body:     bytes.NewReader(content),
+		BodySize: int64(len(content)),
+	})
+	if resp.Err != "" {
+		t.Errorf("Err=%s", resp.Err)
+	}
+	if resp.DiskPath == "" {
+		t.Error("expected non-empty DiskPath")
+	}
+	if resp.Size != int64(len(content)) {
+		t.Errorf("Size=%d, want %d", resp.Size, len(content))
+	}
+}
+
+func TestHandleRequest_Close(t *testing.T) {
+	ctx := context.Background()
+	c := newCacher(t)
+	resp := handleRequest(ctx, c, &request{ID: 11, Command: cmdClose})
+	if resp.ID != 11 {
+		t.Errorf("ID=%d, want 11", resp.ID)
+	}
+	if resp.Err != "" {
+		t.Errorf("Err=%s", resp.Err)
+	}
+}
+
+func TestServe_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	underlying := memblob.OpenBucket(nil)
+	defer underlying.Close()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		err := serve(ctx, underlying, dir, false, inR, outW)
+		outW.Close()
+		done <- err
+	}()
+
+	enc := json.NewEncoder(inW)
+	dec := json.NewDecoder(outR)
+
+	var handshake response
+	if err := dec.Decode(&handshake); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	if len(handshake.KnownCommands) != 3 {
+		t.Errorf("KnownCommands=%v, want 3", handshake.KnownCommands)
+	}
+
+	content := []byte("payload!")
+	outputID := sha256Bytes(content)
+	actionID := bytes.Repeat([]byte{0xab}, 32)
+
+	if err := enc.Encode(request{
+		ID: 1, Command: cmdPut,
+		ActionID: actionID, OutputID: outputID,
+		BodySize: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Encode(content); err != nil {
+		t.Fatal(err)
+	}
+	var putResp response
+	if err := dec.Decode(&putResp); err != nil {
+		t.Fatalf("decode put resp: %v", err)
+	}
+	if putResp.ID != 1 || putResp.Err != "" {
+		t.Errorf("putResp=%+v", putResp)
+	}
+
+	if err := enc.Encode(request{ID: 2, Command: cmdGet, ActionID: actionID}); err != nil {
+		t.Fatal(err)
+	}
+	var getResp response
+	if err := dec.Decode(&getResp); err != nil {
+		t.Fatalf("decode get resp: %v", err)
+	}
+	if getResp.ID != 2 || getResp.Err != "" || getResp.Miss {
+		t.Errorf("getResp=%+v", getResp)
+	}
+	if !bytes.Equal(getResp.OutputID, outputID) {
+		t.Errorf("OutputID mismatch")
+	}
+
+	if err := enc.Encode(request{ID: 3, Command: cmdClose}); err != nil {
+		t.Fatal(err)
+	}
+	var closeResp response
+	if err := dec.Decode(&closeResp); err != nil {
+		t.Fatalf("decode close resp: %v", err)
+	}
+	if closeResp.ID != 3 {
+		t.Errorf("close ID=%d", closeResp.ID)
+	}
+
+	inW.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("serve returned err: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return")
+	}
+}
+
+func TestServe_Readonly_OmitsPut(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	underlying := memblob.OpenBucket(nil)
+	defer underlying.Close()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		err := serve(ctx, underlying, dir, true, inR, outW)
+		outW.Close()
+		done <- err
+	}()
+
+	dec := json.NewDecoder(outR)
+	var handshake response
+	if err := dec.Decode(&handshake); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	if len(handshake.KnownCommands) != 2 {
+		t.Errorf("KnownCommands=%v, want 2 (close, get)", handshake.KnownCommands)
+	}
+	for _, c := range handshake.KnownCommands {
+		if c == cmdPut {
+			t.Error("readonly mode should not advertise cmdPut")
+		}
+	}
+
+	inW.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return")
+	}
+}
+
+func TestServe_BodySizeMismatch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	underlying := memblob.OpenBucket(nil)
+	defer underlying.Close()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		err := serve(ctx, underlying, dir, false, inR, outW)
+		outW.Close()
+		done <- err
+	}()
+
+	dec := json.NewDecoder(outR)
+	var handshake response
+	if err := dec.Decode(&handshake); err != nil {
+		t.Fatal(err)
+	}
+
+	enc := json.NewEncoder(inW)
+	if err := enc.Encode(request{
+		ID: 1, Command: cmdPut,
+		ActionID: bytes.Repeat([]byte{0xab}, 32),
+		OutputID: bytes.Repeat([]byte{0xcd}, 32),
+		BodySize: 10, // claim 10 bytes, send 4
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Encode([]byte("oops")); err != nil {
+		t.Fatal(err)
+	}
+	inW.Close()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "incorrect length") {
+			t.Errorf("expected 'incorrect length' error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return")
+	}
+
+	// Drain any pending response so the test goroutine doesn't leak on outR.
+	io.Copy(io.Discard, outR)
+}
+
+func TestServe_ObjectIDFallback(t *testing.T) {
+	// The pre-Go-1.24 driver sent ObjectID instead of OutputID. Verify that
+	// the server transparently maps it to OutputID for puts.
+	ctx := context.Background()
+	dir := t.TempDir()
+	underlying := memblob.OpenBucket(nil)
+	defer underlying.Close()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		err := serve(ctx, underlying, dir, false, inR, outW)
+		outW.Close()
+		done <- err
+	}()
+
+	enc := json.NewEncoder(inW)
+	dec := json.NewDecoder(outR)
+
+	var handshake response
+	if err := dec.Decode(&handshake); err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte("legacy")
+	outputID := sha256Bytes(content)
+	actionID := bytes.Repeat([]byte{0xab}, 32)
+
+	if err := enc.Encode(request{
+		ID: 1, Command: cmdPut,
+		ActionID: actionID,
+		ObjectID: outputID, // legacy field
+		BodySize: int64(len(content)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Encode(content); err != nil {
+		t.Fatal(err)
+	}
+	var putResp response
+	if err := dec.Decode(&putResp); err != nil {
+		t.Fatal(err)
+	}
+	if putResp.Err != "" {
+		t.Errorf("put err: %s", putResp.Err)
+	}
+
+	// The expected file must be on disk under the OutputID.
+	pathname := filepath.Join(dir, outputDir, hashID(content))
+	if _, err := os.Stat(pathname); errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected file at %s", pathname)
+	}
+
+	inW.Close()
+	<-done
+}
+
+func sha256Bytes(content []byte) []byte {
+	id, err := hex.DecodeString(hashID(content))
+	if err != nil {
+		panic(err)
+	}
+	return id
+}

--- a/storage.go
+++ b/storage.go
@@ -116,7 +116,11 @@ func (d *Disk) OutputIDFromAction(ctx context.Context, actionID string) (string,
 		return "", err
 	}
 
-	return filepath.Base(outputPathname), nil
+	outputID := filepath.Base(outputPathname)
+	if !isValidID(outputID) {
+		return "", fmt.Errorf("invalid output id %q in action symlink %s", outputID, actionPathname)
+	}
+	return outputID, nil
 }
 
 func (d *Disk) LinkActionToOutput(ctx context.Context, actionID, outputID string) (bool, error) {

--- a/storage.go
+++ b/storage.go
@@ -183,7 +183,9 @@ func (b *Bucket) OutputIDFromAction(ctx context.Context, actionID string) (strin
 	slog.Debug("fetched attributes", "action", actionID, "output", outputID, "err", err)
 	if gcerrors.Code(err) == gcerrors.NotFound {
 		slog.Debug("created found", "action", actionID, "output", outputID)
-		os.WriteFile(cacheEmptyOutputPath, nil, 0o600)
+		if err := os.WriteFile(cacheEmptyOutputPath, nil, 0o600); err != nil {
+			slog.Warn("writing empty marker", "action", actionID, "err", err)
+		}
 		return "", nil
 	}
 	if err != nil {
@@ -200,7 +202,9 @@ func (b *Bucket) OutputIDFromAction(ctx context.Context, actionID string) (strin
 	}
 
 	slog.Debug("linking action to output from output from action", "action", actionID, "output", outputID)
-	b.disk.LinkActionToOutput(ctx, actionID, outputID)
+	if _, err := b.disk.LinkActionToOutput(ctx, actionID, outputID); err != nil {
+		slog.Warn("linking action to output", "action", actionID, "output", outputID, "err", err)
+	}
 
 	return outputID, nil
 }

--- a/storage.go
+++ b/storage.go
@@ -66,6 +66,8 @@ type Bucket struct {
 	bucket *blob.Bucket
 	jobs   chan string
 	wg     sync.WaitGroup
+
+	closeOnce sync.Once
 }
 
 func (d *Disk) PutOutput(ctx context.Context, outputID string, r io.Reader) (string, bool, error) {
@@ -217,9 +219,24 @@ func (b *Bucket) PutOutput(ctx context.Context, outputID string, r io.Reader) (s
 	}
 
 	slog.Debug("scheduling upload", "path", pathname)
-	b.jobs <- pathname
+	if err := b.enqueueUpload(pathname); err != nil {
+		return pathname, false, err
+	}
 
 	return pathname, false, nil
+}
+
+// enqueueUpload sends to the job channel, recovering if a concurrent Close
+// has shut it down. A protocol-conformant driver issues no puts after close,
+// but a malformed one would otherwise panic the process.
+func (b *Bucket) enqueueUpload(pathname string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("upload queue closed: %v", r)
+		}
+	}()
+	b.jobs <- pathname
+	return nil
 }
 
 func (b *Bucket) Start(ctx context.Context) {
@@ -253,13 +270,15 @@ func (b *Bucket) Start(ctx context.Context) {
 }
 
 func (b *Bucket) Close() {
-	slog.Debug("waiting for uploads...")
+	b.closeOnce.Do(func() {
+		slog.Debug("waiting for uploads...")
 
-	now := time.Now()
-	close(b.jobs)
-	b.wg.Wait()
+		now := time.Now()
+		close(b.jobs)
+		b.wg.Wait()
 
-	slog.Debug("waited for uploads", "took", time.Since(now))
+		slog.Debug("waited for uploads", "took", time.Since(now))
+	})
 }
 
 func (b *Bucket) GetOutput(ctx context.Context, outputID string) (string, error) {

--- a/storage.go
+++ b/storage.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -282,6 +284,14 @@ func (b *Bucket) GetOutput(ctx context.Context, outputID string) (string, error)
 	}
 	if err != nil {
 		return "", err
+	}
+
+	// outputID is the SHA256 of the cached content (per Go's cache protocol).
+	// Verify before persisting so a poisoned bucket can't feed mismatched bytes
+	// into the build.
+	sum := sha256.Sum256(buf.Bytes())
+	if got := hex.EncodeToString(sum[:]); got != outputID {
+		return "", fmt.Errorf("output %s hash mismatch: got %s", outputID, got)
 	}
 
 	slog.Debug("putting download to disk", "output", outputID, "size", buf.Len())

--- a/storage.go
+++ b/storage.go
@@ -89,7 +89,7 @@ func (d *Disk) PutOutput(ctx context.Context, outputID string, r io.Reader) (str
 	if err != nil {
 		return "", false, fmt.Errorf("creating temporary output file: %w", err)
 	}
-	defer os.RemoveAll(f.Name())
+	defer os.Remove(f.Name())
 	defer f.Close()
 
 	_, err = io.Copy(f, r)
@@ -217,7 +217,7 @@ func (b *Bucket) LinkActionToOutput(ctx context.Context, actionID, outputID stri
 
 	return false, b.bucket.Upload(ctx, path.Join(actionDir, actionID), bytes.NewReader(nil), &blob.WriterOptions{
 		Metadata:    map[string]string{"output_id": outputID},
-		ContentType: "plain/text",
+		ContentType: "text/plain",
 	})
 }
 

--- a/storage.go
+++ b/storage.go
@@ -256,7 +256,7 @@ func (b *Bucket) Start(ctx context.Context) {
 	b.jobs = make(chan string, 1000)
 
 	// 20 workers ought to be enough for anybody
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		b.wg.Add(1)
 		go func() {
 			defer b.wg.Done()

--- a/storage.go
+++ b/storage.go
@@ -299,29 +299,49 @@ func (b *Bucket) GetOutput(ctx context.Context, outputID string) (string, error)
 
 	slog.Debug("downloading", "output", outputID)
 
-	buf := new(bytes.Buffer)
-	err = b.bucket.Download(ctx, path.Join(outputDir, outputID), buf, &blob.ReaderOptions{})
-	slog.Debug("downloaded", "output", outputID, "err", err)
+	rdr, err := b.bucket.NewReader(ctx, path.Join(outputDir, outputID), nil)
 	if gcerrors.Code(err) == gcerrors.NotFound {
 		return "", nil
 	}
 	if err != nil {
 		return "", err
 	}
+	defer rdr.Close()
+
+	f, err := os.CreateTemp(b.disk.cacheDir, "output")
+	if err != nil {
+		return "", fmt.Errorf("creating temporary output file: %w", err)
+	}
+	keep := false
+	defer func() {
+		f.Close()
+		if !keep {
+			os.Remove(f.Name())
+		}
+	}()
 
 	// outputID is the SHA256 of the cached content (per Go's cache protocol).
-	// Verify before persisting so a poisoned bucket can't feed mismatched bytes
+	// Hash while streaming so a poisoned bucket can't feed mismatched bytes
 	// into the build.
-	sum := sha256.Sum256(buf.Bytes())
-	if got := hex.EncodeToString(sum[:]); got != outputID {
+	h := sha256.New()
+	size, err := io.Copy(io.MultiWriter(f, h), rdr)
+	if err != nil {
+		return "", fmt.Errorf("downloading output: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("flushing output: %w", err)
+	}
+
+	if got := hex.EncodeToString(h.Sum(nil)); got != outputID {
 		return "", fmt.Errorf("output %s hash mismatch: got %s", outputID, got)
 	}
 
-	slog.Debug("putting download to disk", "output", outputID, "size", buf.Len())
+	if err := os.Rename(f.Name(), pathname); err != nil {
+		return "", fmt.Errorf("renaming output: %w", err)
+	}
+	keep = true
 
-	pathname, _, err = b.disk.PutOutput(ctx, outputID, bytes.NewReader(buf.Bytes()))
+	slog.Debug("downloaded to disk", "output", outputID, "size", size)
 
-	slog.Debug("putting download to disk done", "output", outputID, "size", buf.Len())
-
-	return pathname, err
+	return pathname, nil
 }

--- a/storage.go
+++ b/storage.go
@@ -23,6 +23,23 @@ const (
 	outputDir = "output"
 )
 
+// isValidID reports whether s is safe to use as a cache ID embedded in a
+// filesystem path. IDs we generate are lowercase hex from hex.EncodeToString;
+// values arriving from untrusted sources (bucket metadata, on-disk symlink
+// targets) must be rejected before they can drive path traversal.
+func isValidID(s string) bool {
+	if len(s) == 0 || len(s) > 128 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
 type OutputInfo struct {
 	ID   string
 	Path string
@@ -161,6 +178,9 @@ func (b *Bucket) OutputIDFromAction(ctx context.Context, actionID string) (strin
 	if outputID == "" {
 		slog.Debug("no metadata output id", "action", actionID, "output", outputID)
 		return "", nil
+	}
+	if !isValidID(outputID) {
+		return "", fmt.Errorf("invalid output_id %q in bucket metadata for action %s", outputID, actionID)
 	}
 
 	slog.Debug("linking action to output from output from action", "action", actionID, "output", outputID)

--- a/storage.go
+++ b/storage.go
@@ -23,6 +23,11 @@ import (
 const (
 	actionDir = "action"
 	outputDir = "output"
+
+	// How long a recorded "this action has no output in the bucket" marker
+	// suppresses re-checking. Long enough to prevent hammering during a single
+	// build, short enough that a freshly-uploaded entry becomes visible soon.
+	emptyMarkerTTL = 10 * time.Minute
 )
 
 // isValidID reports whether s is safe to use as a cache ID embedded in a
@@ -166,9 +171,12 @@ func (b *Bucket) OutputIDFromAction(ctx context.Context, actionID string) (strin
 	// The downside is that if at some point it does exist in remote storage, we might not
 	// immediately observe that.
 	cacheEmptyOutputPath := filepath.Join(b.disk.cacheDir, actionDir, actionID+".empty")
-	if _, err := os.Stat(cacheEmptyOutputPath); err == nil {
-		slog.Debug("empty found", "action", actionID, "output", outputID)
-		return "", nil
+	if fi, err := os.Stat(cacheEmptyOutputPath); err == nil {
+		if time.Since(fi.ModTime()) < emptyMarkerTTL {
+			slog.Debug("empty found", "action", actionID, "output", outputID)
+			return "", nil
+		}
+		slog.Debug("empty marker expired", "action", actionID)
 	}
 
 	attr, err := b.bucket.Attributes(ctx, path.Join(actionDir, actionID))

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,504 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/memblob"
+)
+
+func TestIsValidID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"a", true},
+		{"0123456789abcdef", true},
+		{strings.Repeat("a", 128), true},
+		{strings.Repeat("a", 129), false},
+		{"ABC", false},
+		{"abcg", false},
+		{"abc/def", false},
+		{"../etc/passwd", false},
+		{"abc.def", false},
+		{"abc def", false},
+		{"abc\x00def", false},
+	}
+	for _, tc := range cases {
+		if got := isValidID(tc.in); got != tc.want {
+			t.Errorf("isValidID(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func newDisk(t *testing.T) *Disk {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{actionDir, outputDir} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Disk{cacheDir: dir}
+}
+
+func hashID(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestDiskPutOutput_StoresAndDedupes(t *testing.T) {
+	d := newDisk(t)
+	ctx := context.Background()
+
+	content := []byte("hello world")
+	outputID := hashID(content)
+
+	pathname, exists, err := d.PutOutput(ctx, outputID, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected exists=false on first put")
+	}
+	if want := filepath.Join(d.cacheDir, outputDir, outputID); pathname != want {
+		t.Errorf("pathname=%q, want %q", pathname, want)
+	}
+
+	got, err := os.ReadFile(pathname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("on-disk content=%q, want %q", got, content)
+	}
+
+	pathname2, exists2, err := d.PutOutput(ctx, outputID, bytes.NewReader([]byte("ignored")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists2 {
+		t.Error("expected exists=true on duplicate put")
+	}
+	if pathname2 != pathname {
+		t.Errorf("path differs: %q vs %q", pathname2, pathname)
+	}
+
+	// Existing file is untouched (the second put's body must not overwrite).
+	got, err = os.ReadFile(pathname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("dedupe overwrote: got %q, want %q", got, content)
+	}
+}
+
+func TestDiskGetOutput(t *testing.T) {
+	d := newDisk(t)
+	got, err := d.GetOutput(context.Background(), "abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(d.cacheDir, outputDir, "abc"); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDiskOutputIDFromAction_Missing(t *testing.T) {
+	d := newDisk(t)
+	got, err := d.OutputIDFromAction(context.Background(), "nope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestDiskOutputIDFromAction_RejectsInvalidLink(t *testing.T) {
+	d := newDisk(t)
+	actionID := strings.Repeat("a", 64)
+	actionPath := filepath.Join(d.cacheDir, actionDir, actionID)
+	if err := os.Symlink("../../etc/passwd", actionPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.OutputIDFromAction(context.Background(), actionID); err == nil {
+		t.Error("expected error for invalid symlink target")
+	}
+}
+
+func TestDiskLinkActionToOutput(t *testing.T) {
+	d := newDisk(t)
+	ctx := context.Background()
+
+	actionID := strings.Repeat("a", 64)
+	outputID := strings.Repeat("b", 64)
+
+	exists, err := d.LinkActionToOutput(ctx, actionID, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected exists=false on first link")
+	}
+
+	got, err := d.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != outputID {
+		t.Errorf("got %q, want %q", got, outputID)
+	}
+
+	// Idempotent for unchanged target.
+	exists, err = d.LinkActionToOutput(ctx, actionID, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("expected exists=true on idempotent link")
+	}
+
+	// Replaces symlink when target changes.
+	newOutput := strings.Repeat("c", 64)
+	exists, err = d.LinkActionToOutput(ctx, actionID, newOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected exists=false when target changes")
+	}
+	got, err = d.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != newOutput {
+		t.Errorf("got %q, want %q after relink", got, newOutput)
+	}
+}
+
+func newBucket(t *testing.T) (*Bucket, *blob.Bucket) {
+	t.Helper()
+	d := newDisk(t)
+	underlying := memblob.OpenBucket(nil)
+	t.Cleanup(func() { underlying.Close() })
+	b := &Bucket{disk: d, bucket: underlying}
+	b.Start(context.Background())
+	t.Cleanup(b.Close)
+	return b, underlying
+}
+
+func TestBucketPutOutput_PersistsAndUploads(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	content := []byte("hello bucket")
+	outputID := hashID(content)
+
+	pathname, exists, err := b.PutOutput(ctx, outputID, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected exists=false")
+	}
+
+	// On-disk first; upload happens via worker.
+	if got, err := os.ReadFile(pathname); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, content) {
+		t.Errorf("disk content mismatch")
+	}
+
+	// Drain the upload queue.
+	b.Close()
+
+	got, err := underlying.ReadAll(ctx, path.Join(outputDir, outputID))
+	if err != nil {
+		t.Fatalf("read uploaded: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("uploaded content mismatch")
+	}
+}
+
+func TestBucketGetOutput_DownloadsAndPersists(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	content := []byte("downloadable")
+	outputID := hashID(content)
+	if err := underlying.WriteAll(ctx, path.Join(outputDir, outputID), content, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	pathname, err := b.GetOutput(ctx, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(b.disk.cacheDir, outputDir, outputID); pathname != want {
+		t.Errorf("pathname=%q, want %q", pathname, want)
+	}
+	if got, err := os.ReadFile(pathname); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, content) {
+		t.Errorf("on-disk content mismatch")
+	}
+}
+
+func TestBucketGetOutput_DiskCacheHit(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	content := []byte("cached")
+	outputID := hashID(content)
+	pathname := filepath.Join(b.disk.cacheDir, outputDir, outputID)
+	if err := os.WriteFile(pathname, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bucket is empty — if GetOutput tries to download, we'd see a NotFound miss
+	// (returning ""). Disk hit avoids that.
+	got, err := b.GetOutput(ctx, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != pathname {
+		t.Errorf("got %q, want %q", got, pathname)
+	}
+
+	// Verify by uploading a different blob and confirming disk cache wins.
+	if err := underlying.WriteAll(ctx, path.Join(outputDir, outputID), []byte("other"), nil); err != nil {
+		t.Fatal(err)
+	}
+	got2, err := b.GetOutput(ctx, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	on, err := os.ReadFile(got2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(on, content) {
+		t.Errorf("disk cache was overwritten by remote content")
+	}
+}
+
+func TestBucketGetOutput_HashMismatch(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	realContent := []byte("good")
+	outputID := hashID(realContent)
+	if err := underlying.WriteAll(ctx, path.Join(outputDir, outputID), []byte("evil!"), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := b.GetOutput(ctx, outputID)
+	if err == nil {
+		t.Fatal("expected hash mismatch error")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Errorf("err=%v, want hash mismatch", err)
+	}
+
+	// Corrupt content must not have been persisted.
+	pathname := filepath.Join(b.disk.cacheDir, outputDir, outputID)
+	if _, err := os.Stat(pathname); !errors.Is(err, fs.ErrNotExist) {
+		t.Error("hash-mismatched file was persisted to disk")
+	}
+}
+
+func TestBucketGetOutput_NotFound(t *testing.T) {
+	ctx := context.Background()
+	b, _ := newBucket(t)
+	got, err := b.GetOutput(ctx, strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty on miss", got)
+	}
+}
+
+func TestBucketOutputIDFromAction_RejectsBadMetadata(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	actionID := strings.Repeat("a", 64)
+	if err := underlying.Upload(ctx, path.Join(actionDir, actionID), bytes.NewReader(nil), &blob.WriterOptions{
+		ContentType: "text/plain",
+		Metadata:    map[string]string{"output_id": "../../etc/passwd"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := b.OutputIDFromAction(ctx, actionID); err == nil {
+		t.Error("expected error for invalid metadata output_id")
+	}
+}
+
+func TestBucketOutputIDFromAction_FromMetadata(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	actionID := strings.Repeat("a", 64)
+	outputID := strings.Repeat("b", 64)
+	if err := underlying.Upload(ctx, path.Join(actionDir, actionID), bytes.NewReader(nil), &blob.WriterOptions{
+		ContentType: "text/plain",
+		Metadata:    map[string]string{"output_id": outputID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := b.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != outputID {
+		t.Errorf("got %q, want %q", got, outputID)
+	}
+
+	// Disk symlink should now exist for fast subsequent lookups.
+	diskGot, err := b.disk.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diskGot != outputID {
+		t.Errorf("disk got %q, want %q", diskGot, outputID)
+	}
+}
+
+func TestBucketOutputIDFromAction_EmptyMetadata(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	actionID := strings.Repeat("a", 64)
+	if err := underlying.Upload(ctx, path.Join(actionDir, actionID), bytes.NewReader(nil), &blob.WriterOptions{
+		ContentType: "text/plain",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := b.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty when metadata absent", got)
+	}
+}
+
+func TestBucketOutputIDFromAction_EmptyMarkerTTL(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	actionID := strings.Repeat("a", 64)
+
+	// First call: bucket miss writes marker.
+	got, err := b.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty on first miss", got)
+	}
+	markerPath := filepath.Join(b.disk.cacheDir, actionDir, actionID+".empty")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected marker at %s: %v", markerPath, err)
+	}
+
+	// Now upload an action so the bucket would resolve. Within TTL, marker
+	// suppresses the lookup.
+	expected := strings.Repeat("b", 64)
+	if err := underlying.Upload(ctx, path.Join(actionDir, actionID), bytes.NewReader(nil), &blob.WriterOptions{
+		ContentType: "text/plain",
+		Metadata:    map[string]string{"output_id": expected},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = b.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("expected marker to suppress, got %q", got)
+	}
+
+	// Backdate marker past TTL; lookup should now go through.
+	past := time.Now().Add(-2 * emptyMarkerTTL)
+	if err := os.Chtimes(markerPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+	got, err = b.OutputIDFromAction(ctx, actionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != expected {
+		t.Errorf("got %q, want %q after TTL expiry", got, expected)
+	}
+}
+
+func TestBucketLinkActionToOutput(t *testing.T) {
+	ctx := context.Background()
+	b, underlying := newBucket(t)
+
+	actionID := strings.Repeat("a", 64)
+	outputID := strings.Repeat("b", 64)
+
+	exists, err := b.LinkActionToOutput(ctx, actionID, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected exists=false on first link")
+	}
+
+	attrs, err := underlying.Attributes(ctx, path.Join(actionDir, actionID))
+	if err != nil {
+		t.Fatalf("bucket Attributes: %v", err)
+	}
+	if attrs.Metadata["output_id"] != outputID {
+		t.Errorf("metadata=%v, want output_id=%s", attrs.Metadata, outputID)
+	}
+
+	// Idempotent path skips the bucket upload but still reports exists=true.
+	exists, err = b.LinkActionToOutput(ctx, actionID, outputID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("expected exists=true on idempotent link")
+	}
+}
+
+func TestBucketCloseIdempotent(t *testing.T) {
+	b, _ := newBucket(t)
+	b.Close()
+	b.Close() // would panic without sync.Once
+}
+
+func TestBucketPutAfterClose(t *testing.T) {
+	ctx := context.Background()
+	b, _ := newBucket(t)
+	b.Close()
+
+	content := []byte("hi")
+	_, _, err := b.PutOutput(ctx, hashID(content), bytes.NewReader(content))
+	if err == nil {
+		t.Error("expected error from PutOutput after Close")
+	}
+}


### PR DESCRIPTION
 ## Summary

A grab-bag of correctness, security, and reliability fixes for the cache plugin, plus a substantial test suite, thanks to Claude.

  ### Security
  - Validate hex IDs from untrusted sources (action symlink targets and bucket metadata) before using them in filesystem paths to prevent path traversal.
  - Verify SHA256 of downloaded outputs against the requested `outputID` so a poisoned bucket can't feed mismatched bytes into a build.
  - Tighten cache directory permissions from `0o777` to `0o755`.

  ### Reliability
  - Stream bucket downloads directly to a temp file instead of buffering the whole object in memory (`bytes.Buffer`), avoiding OOM on large outputs.
  - Make `Bucket.Close` idempotent via `sync.Once`, and recover from sends on the closed jobs channel so a malformed driver can't panic the process.
  - Expire negative ("not in bucket") cache markers after 10 minutes so freshly-uploaded entries become visible without a fresh build.
  - Log previously swallowed errors from `WriteFile`, `LinkActionToOutput`, etc.

  ### Bug fixes
  - Fix `Content-Type` typo (`plain/text` → `text/plain`) on action uploads.
  - Use `os.Remove` (not `os.RemoveAll`) for the single temp output file.
  - Don't `os.Stat` an empty `DiskPath` on cache miss — the resulting error was being reported as a real failure.

  ### Refactor + tests
  - Split `run` into `run` / `serve` / `handleRequest` so the protocol layer can be exercised without spinning up a real bucket. Adds ~985 lines of unit tests across `main_test.go` and `storage_test.go`.

  ### Misc
  - `.gitignore` for built binaries.
  - README: document `go install` and drop `./` from the `GOCACHEPROG` example.
  - `go fix` pass (e.g. `for range 20`).

  ## Test plan
  - [x] `go test ./...` passes
  - [ ] Smoke test: build a real Go project with `GOCACHEPROG="gobuildcache <bucket>"`, confirm hits/misses behave and uploads complete on exit
  - [ ] Verify a corrupted object in the bucket is rejected (hash mismatch error, not silently used)